### PR TITLE
Post collect fix

### DIFF
--- a/deep_collector/utils.py
+++ b/deep_collector/utils.py
@@ -121,7 +121,7 @@ class RelatedObjectsCollector(object):
     def clean_by_fields(self, obj, fields, get_field_fn, exclude_list):
         """
         Function used to exclude defined fields from object collect.
-        :param parent: the object we are collecting
+        :param obj: the object we are collecting
         :param fields: every field related to this object (direct or reverse one)
         :param get_field_fn: function used to get accessor for each field
         :param exclude_list: model/fields we have defined to be excluded from collect
@@ -185,11 +185,11 @@ class RelatedObjectsCollector(object):
         return is_excluded_model
 
     def _is_same_type_as_root(self, obj):
-        '''
+        """
         Testing if we try to collect an object of the same type as root.
         This is not really a good sign, because it means that we are going to collect a whole new tree, that will
         maybe collect a new tree, that will...
-        '''
+        """
         if not self.ALLOWS_SAME_TYPE_AS_ROOT_COLLECT:
             obj_model = get_model_from_instance(obj)
             obj_key = get_key_from_instance(obj)

--- a/deep_collector/utils.py
+++ b/deep_collector/utils.py
@@ -279,10 +279,7 @@ class RelatedObjectsCollector(object):
         """
         if not self.ALLOWS_SAME_TYPE_AS_ROOT_COLLECT:
             for field in self.get_local_fields(obj):
-                if not isinstance(field, ForeignKey) or field.unique or field.rel.to != type(self.root_obj):
-                    continue
-                instance_id = getattr(obj, field.name + '_id')
-                if instance_id != self.root_obj.id:
+                if isinstance(field, ForeignKey) and not field.unique and field.rel.to == type(self.root_obj):
                     setattr(obj, field.name, self.root_obj)
 
     def get_local_fields(self, obj):

--- a/tests/models.py
+++ b/tests/models.py
@@ -53,3 +53,13 @@ class ClassLevel3(models.Model):
 
 class ChildModel(BaseModel):
     child_field = models.CharField(max_length=255)
+
+
+class InvalidFKRootModel(models.Model):
+    valid_fk = models.ForeignKey('InvalidFKNonRootModel', related_name='valid_non_root_fk', null=True)
+    invalid_fk = models.ForeignKey('InvalidFKNonRootModel', related_name='invalid_non_root_fk', null=True)
+
+
+class InvalidFKNonRootModel(models.Model):
+    valid_fk = models.ForeignKey(InvalidFKRootModel, related_name='valid_root_fk', null=True)
+    invalid_fk = models.ForeignKey(InvalidFKRootModel, related_name='invalid_root_fk', null=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,7 +7,7 @@ from .factories import (BaseModelFactory, ManyToManyToBaseModelFactory,
                         ManyToManyToBaseModelWithRelatedNameFactory, ChildModelFactory)
 from deep_collector.serializers import MultiModelInheritanceSerializer
 from deep_collector.utils import RelatedObjectsCollector
-from .models import ForeignKeyToBaseModel
+from .models import ForeignKeyToBaseModel, InvalidFKRootModel, InvalidFKNonRootModel
 
 
 class TestDirectRelations(TestCase):
@@ -177,3 +177,36 @@ class TestMultiModelInheritanceSerializer(TestCase):
 
         self.assertEqual(local_fields_before, local_fields_after)
         self.assertEqual(local_m2m_fields_before, local_m2m_fields_after)
+
+
+class TestPostCollect(TestCase):
+    @staticmethod
+    def _generate_invalid_id(model):
+        instance = model.objects.create()
+        invalid_id = instance.id
+        instance.delete()
+        return invalid_id
+
+    def test_invalid_foreign_key_doesnt_cause_matching_query_does_not_exist_exception(self):
+        root = InvalidFKRootModel.objects.create()
+        non_root = InvalidFKNonRootModel.objects.create()
+
+        root.invalid_fk_id = self._generate_invalid_id(InvalidFKNonRootModel)
+        root.valid_fk = non_root
+        root.save()
+
+        non_root.invalid_fk_id = self._generate_invalid_id(InvalidFKRootModel)
+        non_root.valid_fk = root
+        non_root.save()
+
+        # when post_collect() is executed on the InvalidFKRootModel instance
+        # this invalid foreign key shouldn't cause an error like:
+        # "DoesNotExist: InvalidFKRootModel matching query does not exist."
+        # OR
+        # "DoesNotExist: InvalidFKNonRootModel matching query does not exist."
+
+        collector = RelatedObjectsCollector()
+        collector.collect(root)
+
+        self.assertIn(root, collector.get_collected_objects())
+        self.assertIn(non_root, collector.get_collected_objects())


### PR DESCRIPTION
The `getattr()` call caused fetching objects identified by the foreign key. In some cases this raised `DoesNotExist` exception.

bug elimination: instance.id was compared with a string (this always resulted in True)
