### PR TITLE
in Django 1.9 RemovedInDjango19Warning is not there anymore

### DIFF
--- a/deep_collector/compat/serializers/django_1_7.py
+++ b/deep_collector/compat/serializers/django_1_7.py
@@ -1,7 +1,6 @@
 import warnings
 from django.core.serializers.json import Serializer
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango19Warning
 
 
 class CustomizableLocalFieldsSerializer(Serializer):
@@ -20,6 +19,7 @@ class CustomizableLocalFieldsSerializer(Serializer):
         """
         Serialize a queryset.
         """
+        from django.utils.deprecation import RemovedInDjango19Warning
         self.options = options
 
         self.stream = options.pop("stream", six.StringIO())


### PR DESCRIPTION
Since the import for that warning is done at compile time it can be
simply moved in the function