### PR TITLE
Use get_fields() instead of unofficial APIs

### DIFF
--- a/deep_collector/compat/meta.py
+++ b/deep_collector/compat/meta.py
@@ -1,9 +1,28 @@
 import django
 
 if django.VERSION < (1, 8):
+    def get_all_related_objects(obj):
+        return obj._meta.get_all_related_objects()
+
+    def get_all_related_m2m_objects_with_model(obj):
+        return obj._meta.get_all_related_m2m_objects_with_model()
+
     def get_compat_local_fields(obj):
         # virtual_fields are used to collect GenericForeignKey objects
         return obj._meta.local_fields + obj._meta.virtual_fields
 else:
+    def get_all_related_objects(obj):
+        return  [
+            f for f in obj._meta.get_fields()
+            if (f.one_to_many or f.one_to_one) and f.auto_created
+        ]
+
+    def get_all_related_m2m_objects_with_model(obj):
+        return  [
+            (f, f.model if f.model != obj.__class__ else None)
+            for f in obj._meta.get_fields(include_hidden=True)
+            if f.many_to_many and f.auto_created
+        ]
+
     def get_compat_local_fields(obj):
         return obj._meta.get_fields()

--- a/deep_collector/core.py
+++ b/deep_collector/core.py
@@ -5,7 +5,9 @@ from django.db.models import ForeignKey, OneToOneField
 
 from .compat.builtins import basestring, StringIO
 from .compat.fields import GenericForeignKey, GenericRelation
-from .compat.meta import get_compat_local_fields
+from .compat.meta import (get_all_related_objects,
+                          get_all_related_m2m_objects_with_model,
+                          get_compat_local_fields)
 from .compat.serializers import MultiModelInheritanceSerializer
 
 
@@ -405,11 +407,11 @@ class RelatedObjectsCollector(object):
         return local_objs
 
     def get_related_fields(self, obj):
-        return self.clean_by_fields(obj, obj._meta.get_all_related_objects(),
+        return self.clean_by_fields(obj, get_all_related_objects(obj),
                           lambda x: x.get_accessor_name(), self.EXCLUDE_RELATED_FIELDS)
 
     def get_related_m2m_fields(self, obj):
-        return self.clean_by_fields(obj, obj._meta.get_all_related_m2m_objects_with_model(),
+        return self.clean_by_fields(obj, get_all_related_m2m_objects_with_model(obj),
                           lambda x:x[0].get_accessor_name(), self.EXCLUDE_RELATED_FIELDS)
 
     def get_related_objs(self, obj):


### PR DESCRIPTION
Both get_all_related_m2m_objects_with_model and
get_all_related_objects are scheduled for removal in Django 1.10
and their use generates warnings, e.g.

    RemovedInDjango110Warning: 'get_all_related_objects is an
        unofficial API that has been deprecated. You may be able
        to replace it with 'get_fields()'

The Django docs have drop-in replacement code using get fields:

    https://docs.djangoproject.com/en/1.9/ref/models/meta/

This introduces a compatibility layer for these APIs, Django
versions prior to 1.8 will pass through to the original methods and
1.8 and 1.9 will use the replacement code based on get_fields as
given in the Django docs.