### PR TITLE
Fix for problems with inherited models

### DIFF
--- a/deep_collector/compat/meta.py
+++ b/deep_collector/compat/meta.py
@@ -14,7 +14,8 @@ else:
     def get_all_related_objects(obj):
         return  [
             f for f in obj._meta.get_fields()
-            if (f.one_to_many or f.one_to_one) and f.auto_created
+            if (f.one_to_many or f.one_to_one) and 
+               f.auto_created and not f.concrete
         ]
 
     def get_all_related_m2m_objects_with_model(obj):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,7 +3,7 @@ import factory
 
 from .models import (FKDummyModel, O2ODummyModel, BaseModel, ManyToManyToBaseModel,
     ForeignKeyToBaseModel, OneToOneToBaseModel, ClassLevel1, ClassLevel2, ClassLevel3,
-    ManyToManyToBaseModelWithRelatedName, ChildModel)
+    ManyToManyToBaseModelWithRelatedName, ChildModel, SubClassOfBaseModel)
 
 
 class FKDummyModelFactory(factory.django.DjangoModelFactory):
@@ -26,6 +26,11 @@ class BaseModelFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = BaseModel
+
+
+class SubClassOfBaseModelFactory(BaseModelFactory):
+    class Meta:
+        model = SubClassOfBaseModel
 
 
 class ManyToManyToBaseModelFactory(factory.django.DjangoModelFactory):

--- a/tests/models.py
+++ b/tests/models.py
@@ -19,6 +19,10 @@ class BaseModel(models.Model):
     o2o = models.OneToOneField(O2ODummyModel)
 
 
+class SubClassOfBaseModel(BaseModel):
+    pass
+
+
 class ManyToManyToBaseModel(models.Model):
     name = models.CharField(max_length=255)
     m2m = models.ManyToManyField(BaseModel)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,10 +3,11 @@ from django.test import TestCase
 
 from .factories import (BaseModelFactory, ManyToManyToBaseModelFactory,
                         ForeignKeyToBaseModelFactory, ClassLevel3Factory,
-                        ManyToManyToBaseModelWithRelatedNameFactory)
+                        ManyToManyToBaseModelWithRelatedNameFactory,
+                        SubClassOfBaseModelFactory)
 from deep_collector.utils import RelatedObjectsCollector
 from .models import ForeignKeyToBaseModel, InvalidFKRootModel, InvalidFKNonRootModel, BaseModel, GFKModel, \
-    BaseToGFKModel
+    BaseToGFKModel, SubClassOfBaseModel
 
 
 class TestDirectRelations(TestCase):
@@ -32,6 +33,13 @@ class TestDirectRelations(TestCase):
         collector = RelatedObjectsCollector()
         collector.collect(m2m_model)
         self.assertIn(obj, collector.get_collected_objects())
+
+    def test_one_to_one_object_inherited(self):
+        obj = SubClassOfBaseModelFactory.create()
+
+        collector = RelatedObjectsCollector()
+        collector.collect(obj)
+        self.assertIn(obj.o2o, collector.get_collected_objects())
 
 
 class TestReverseRelations(TestCase):


### PR DESCRIPTION
b4b7e1a adds two tests, one that reproduces the problem and another to check that it doesn't happen with inherited M2M fields too. In e04bffe there's a change that makes those test pass **but** I am really not confident that it is the true and proper solution to this problem (it's start though) :)