### PR TITLE
Revert "Update README examples to reflect naming changes"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,15 +10,15 @@ Django custom collector used to get every objects that are related to given obje
 Usage
 =====
 
-Create a new instance of RelatedObjectsCollector, and launch collector on one object:
+Create a new instance of DeepCollector, and launch collector on one object:
 
 .. code-block:: python
 
-    from deep_collector.core import RelatedObjectsCollector
+    from deep_collector.core import DeepCollector
     from django.contrib.auth.models import User
 
     user = User.objects.all()[0]
-    collector = RelatedObjectsCollector()
+    collector = DeepCollector()
     collector.collect(user)
     related_objects = collector.get_collected_objects()
 


### PR DESCRIPTION
Reverts iwoca/django-deep-collector#31

My bad, the `RelatedObjectCollector` naming is the old one, `DeepCollector` is the new one.